### PR TITLE
Code Review

### DIFF
--- a/lib/ZKGroupMembership.js
+++ b/lib/ZKGroupMembership.js
@@ -127,7 +127,7 @@ class ZKGroupMembership extends EventEmitter {
      * @return {string}
      */
     getMemberPath(id) {
-        id = typeof id !== "string" ? String(id) : id;
+        id = typeof id !== 'string' ? String(id) : id;
         return id.includes('/') ? undefined : [this.groupPath, id].join('/');
     }
 
@@ -137,7 +137,7 @@ class ZKGroupMembership extends EventEmitter {
      * @return {Promise} resolved with {id, data} once the given member is registered.
      */
     registerMember(id, data = {}) {
-        if (typeof id === "undefined") {
+        if (typeof id === 'undefined') {
             id = uuid();
         }
         const path = this.getMemberPath(id);

--- a/lib/ZKGroupMembership.js
+++ b/lib/ZKGroupMembership.js
@@ -75,12 +75,12 @@ class ZKGroupMembership extends EventEmitter {
                 groupPath = '/groups/default',
                 conf = {}) {
         super();
-        this.groupPath = groupPath;
-        this.timeout = conf.timeout;
-        this.setupTimeout = conf.setupTimeout;
+        this._groupPath = groupPath;
+        this._timeout = conf.timeout;
+        this._setupTimeout = conf.setupTimeout;
         this._membersChangedListener = null;
 
-        this.client = client;
+        this._client = client;
     }
 
     /**
@@ -89,7 +89,7 @@ class ZKGroupMembership extends EventEmitter {
      * @return {Promise.<ZKGroupMembership>}
      */
     setup() {
-        return timedPromiseByCallback(cb => this.client.mkdirp(this.groupPath, cb), this.setupTimeout).then(() => this);
+        return timedPromiseByCallback(cb => this._client.mkdirp(this._groupPath, cb), this._setupTimeout).then(() => this);
     }
 
     /**
@@ -97,7 +97,7 @@ class ZKGroupMembership extends EventEmitter {
      * @return {*}
      */
     getMembers() {
-        return timedPromiseByCallback(cb => this.client.getChildren(this.groupPath, this._membersChangedListener, cb), this.timeout);
+        return timedPromiseByCallback(cb => this._client.getChildren(this._groupPath, this._membersChangedListener, cb), this._timeout);
     }
 
     /**
@@ -113,7 +113,7 @@ class ZKGroupMembership extends EventEmitter {
                 this.getMembers().then(nodeList => this.emit('members', nodeList), err => this.emit('error', err));
             };
             this._membersChangedListener();
-            this.client.on('state', state => {
+            this._client.on('state', state => {
                 if (state.name !== 'SYNC_CONNECTED') {
                     this.emit('error', new Error('Disconnected'));
                 }
@@ -130,7 +130,7 @@ class ZKGroupMembership extends EventEmitter {
      */
     getMemberPath(id) {
         id = typeof id !== 'string' ? String(id) : id;
-        return id.includes('/') ? undefined : [this.groupPath, id].join('/');
+        return id.includes('/') ? undefined : [this._groupPath, id].join('/');
     }
 
     /**
@@ -153,7 +153,7 @@ class ZKGroupMembership extends EventEmitter {
         const asBuffer = new Buffer(JSON.stringify(data));
 
         return timedPromiseByCallback(
-            cb => this.client.create(path, asBuffer, null/*ACL*/, ZK_CREATE_MODE_EPHEMERAL, cb), this.timeout)
+            cb => this._client.create(path, asBuffer, null/*ACL*/, ZK_CREATE_MODE_EPHEMERAL, cb), this._timeout)
             .then(() => ({ id: id,  data: data }));
     }
 
@@ -170,7 +170,7 @@ class ZKGroupMembership extends EventEmitter {
         if (!path) {
             return Promise.reject(new Error('Illegal member ID'));
         }
-        return timedPromiseByCallback(cb => this.client.getData(path, null, cb), this.timeout, true).then(([buffer, stat]) => {
+        return timedPromiseByCallback(cb => this._client.getData(path, null, cb), this._timeout, true).then(([buffer, stat]) => {
             return { id: id,  data: JSON.parse(buffer.toString()), stat: stat };
         });
     }

--- a/lib/ZKGroupMembership.js
+++ b/lib/ZKGroupMembership.js
@@ -56,7 +56,7 @@ function delay(timeout) {
 function withTimeout(promise, timeout) {
     return typeof timeout === 'undefined' ? promise : Promise.race([
         promise,
-        delay(timeout).then(() => Promise.reject(new Error('Timeout')))
+        delay(timeout).then(() => { throw new Error('Timeout'); })
     ]);
 }
 
@@ -110,12 +110,12 @@ class ZKGroupMembership extends EventEmitter {
     startMonitor() {
         if (!this._membersChangedListener) {
             this._membersChangedListener = () => {
-                this.getMembers().then(nodeList => this.emit('members', nodeList), err => this.emit('error', err));
+                this.getMembers().then(nodeList => super.emit('members', nodeList), err => super.emit('error', err));
             };
             this._membersChangedListener();
             this._client.on('state', state => {
                 if (state.name !== 'SYNC_CONNECTED') {
-                    this.emit('error', new Error('Disconnected'));
+                    super.emit('error', new Error('Disconnected'));
                 }
             }); //when we monitor, we should be aware of disconnections
         }
@@ -154,7 +154,7 @@ class ZKGroupMembership extends EventEmitter {
 
         return timedPromiseByCallback(
             cb => this._client.create(path, asBuffer, null/*ACL*/, ZK_CREATE_MODE_EPHEMERAL, cb), this._timeout)
-            .then(() => ({ id: id,  data: data }));
+            .then(() => ({id, data}));
     }
 
     /**
@@ -171,7 +171,7 @@ class ZKGroupMembership extends EventEmitter {
             return Promise.reject(new Error('Illegal member ID'));
         }
         return timedPromiseByCallback(cb => this._client.getData(path, null, cb), this._timeout, true).then(([buffer, stat]) => {
-            return { id: id,  data: JSON.parse(buffer.toString()), stat: stat };
+            return {id,  data: JSON.parse(buffer.toString()), stat};
         });
     }
 }

--- a/lib/ZKGroupMembership.js
+++ b/lib/ZKGroupMembership.js
@@ -1,12 +1,13 @@
 const {EventEmitter} = require('events');
-const ZK_CREATE_MODE_EPHEMERAL = 1;
 const uuid = require('uuid/v4');
+
+const ZK_CREATE_MODE_EPHEMERAL = 1;
 
 /**
  * Returns a node style callback for the given promise resolve/reject arguments.
  * @param resolve
  * @param reject
- * @param array if true all values given to the callback after err are resolved as an array. Otherwise the first value is resolved.
+ * @param [array] if true all values given to the callback after err are resolved as an array. Otherwise the first value is resolved.
  * @return {*}
  */
 function resolverAsCallback(resolve, reject, array = false) {
@@ -49,7 +50,7 @@ function delay(timeout) {
  * Returns the given promise if timeout is undefined, otherwise returns a promise that is rejected with a timeout error
  * within if the given timeout occurs before the original promise is resolved/rejected.
  * @param {Promise.<*>} promise
- * @param {Number} timeout
+ * @param {Number} [timeout]
  * @return {Promise.<*>}
  */
 function withTimeout(promise, timeout) {
@@ -61,14 +62,14 @@ function withTimeout(promise, timeout) {
 
 class ZKGroupMembership extends EventEmitter {
     /**
+     * Creates a new ZKGroupMembership instance.
      *
      * @param {Zookeeper} client a Zookeeper client instance.
-     * @param {string} groupPath The path to the under which members will be registered and the location that will be monitored,
+     * @param {string} [groupPath] The path to the under which members will be registered and the location that will be monitored,
      * defaults to 'groups/default'
-     * @param {Object} conf optional timeout configuration
-     * @param {Number} conf.setupTimeout Optional timeout for setup
-     * @param {Number} conf.timeout Optional timeout for registering nodes and retrieving nodes during monitor
-
+     * @param {Object} [conf] optional timeout configuration
+     * @param {Number} [conf.setupTimeout] Optional timeout for setup
+     * @param {Number} [conf.timeout] Optional timeout for registering nodes and retrieving nodes during monitor
      */
     constructor(client,
                 groupPath = '/groups/default',
@@ -122,7 +123,8 @@ class ZKGroupMembership extends EventEmitter {
     }
 
     /**
-     * if id contains '/' returns undefined. Otherwise returns the full path in ZK to the znode for that member.
+     * If id contains '/' returns undefined. Otherwise returns the full path in ZK to the znode for that member.
+     *
      * @param id the member id
      * @return {string}
      */
@@ -133,7 +135,9 @@ class ZKGroupMembership extends EventEmitter {
 
     /**
      * Registers a group member with the given metadata.
-     * @param {object} data optional data to be associated with the member. defaults to {}.
+     *
+     * @param id the member id
+     * @param {object} [data] optional data to be associated with the member. defaults to {}.
      * @return {Promise} resolved with {id, data} once the given member is registered.
      */
     registerMember(id, data = {}) {
@@ -155,7 +159,8 @@ class ZKGroupMembership extends EventEmitter {
 
     /**
      * Registers a group member with the given metadata.
-     * @param {object | string} memberData optional either a id string or object metadata associated with the member (that may
+     *
+     * @param {object | string} id optional either a id string or object metadata associated with the member (that may
      * contain an id: string field).
      * @return {Promise} resolved once the given member is registered,
      * @throws {Error} If the memberData id contains a '/'

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
   "version": "2.0.1",
   "description": "This package uses zookeeper to manage a group of members, allowing to register new group members and monitoring when members are added or removed.",
   "main": "index.js",
-  "devDependencies": {},
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "mocha": "^3.4.2"
+  },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "eslint ./lib"
   },
   "keywords": [
     "zookeeper",


### PR DESCRIPTION
No major issues found. This PR just includes minor changes:
* added mocha & eslint as devDependencies since those are used for testing/linting
* fixed two minor eslint issues + some improvements to jsdoc
* prefix all private properties and methods with underscore (well this doesn't really make them private (it's the JS world... there is no such thing (*)) but it's common convention to "mark" private stuff with an `_` prefix)
* no need to create new reject promise inside a then-promise function just throw the error
* replaced the `this.emit` calls with `super.emit`. no functional difference, but clarifies to the reader that the called method is from the super (`EventEmitter`) class
- small simplification of object creations

We can discuss the changes in this PR and update it if needed.

(*) maybe in the future: https://tc39.github.io/proposal-private-fields/